### PR TITLE
feat: add wireframe-style contact strip to footer

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -710,6 +710,51 @@
   display: none;
 }
 
+/* contact strip */
+.contact-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 9px;
+  margin-bottom: 30px;
+  justify-content: center;
+}
+.contact-mini {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--wf-marker);
+  font-size: 14px;
+  color: var(--wf-ink);
+  text-decoration: none;
+  padding: 7px 13px 7px 11px;
+  background: var(--wf-paper);
+}
+.contact-mini > .sketch-edge {
+  position: absolute;
+  inset: 0;
+  border: 2.2px solid var(--wf-ink);
+  border-radius: 18px;
+  filter: url(#wobble);
+  pointer-events: none;
+}
+.contact-mini svg {
+  width: 16px;
+  height: 16px;
+  flex: none;
+  fill: none;
+  stroke: var(--wf-ink);
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+a.contact-mini:hover {
+  color: var(--wf-accent);
+}
+a.contact-mini:hover svg {
+  stroke: var(--wf-accent);
+}
+
 @media (max-width: 640px) {
   .wf-hero-grid {
     grid-template-columns: 1fr !important;

--- a/src/components/wireframe-home.tsx
+++ b/src/components/wireframe-home.tsx
@@ -66,6 +66,13 @@ export function WireframeHome({ profile }: { profile: IProfile }) {
   useEffect(() => {
     if (!rootRef.current) return;
     paintEdges(rootRef.current);
+    rootRef.current.querySelectorAll(".contact-mini").forEach((el) => {
+      if (!el.querySelector(":scope > .sketch-edge")) {
+        const e = document.createElement("div");
+        e.className = "sketch-edge";
+        el.insertBefore(e, el.firstChild);
+      }
+    });
     const io = new IntersectionObserver(
       (entries) =>
         entries.forEach((e) => {
@@ -876,6 +883,43 @@ export function WireframeHome({ profile }: { profile: IProfile }) {
           >
             Introverted, but always up for a good build. Find me here:
           </p>
+
+          {/* contact strip */}
+          <div className="contact-strip wf-reveal">
+            <span className="contact-mini">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 21s-7-5.5-7-11a7 7 0 0 1 14 0c0 5.5-7 11-7 11z" />
+                <circle cx="12" cy="10" r="2.5" />
+              </svg>
+              Phnom Penh, KH
+            </span>
+            <a className="contact-mini" href="tel:+85570647779">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M4 5c0 9 6 15 15 15a2 2 0 0 0 2-2v-2.5a1 1 0 0 0-.8-1l-3.4-.7a1 1 0 0 0-1 .4l-1 1.3a12 12 0 0 1-5-5l1.3-1a1 1 0 0 0 .4-1L10.5 5.8a1 1 0 0 0-1-.8H6a2 2 0 0 0-2 2z" />
+              </svg>
+              +855 70 647 779
+            </a>
+            <a className="contact-mini" href="mailto:lorn.samnang.it@gmail.com">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="3" y="5" width="18" height="14" rx="2" />
+                <path d="M4 7l8 6 8-6" />
+              </svg>
+              lorn.samnang.it@gmail.com
+            </a>
+            <a
+              className="contact-mini"
+              href="https://lornsamnang.com"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M10 14a4 4 0 0 0 5.6 0l3-3a4 4 0 0 0-5.6-5.6l-1.5 1.5" />
+                <path d="M14 10a4 4 0 0 0-5.6 0l-3 3a4 4 0 0 0 5.6 5.6l1.5-1.5" />
+              </svg>
+              lornsamnang.com
+            </a>
+          </div>
+
           <div
             className="wf-reveal d1"
             style={{


### PR DESCRIPTION
## Summary

- Adds a horizontal row of hand-drawn pill chips in the wireframe theme footer (location, phone, email, website)
- Each chip gets a `.sketch-edge` overlay with `border-radius: 18px` and `filter: url(#wobble)` for the sketchy hand-drawn look
- Phone, email, and website chips are real links that turn red (`--wf-accent`) on hover; location chip is non-interactive
- Uses the existing `Architects Daughter` marker font and wobble SVG filter already in the component

## Test plan

- [ ] Visit the portfolio in wireframe theme mode
- [ ] Scroll to the footer `#contact` section
- [ ] Confirm the four chips appear in a horizontal row: Phnom Penh KH, +855 70 647 779, lorn.samnang.it@gmail.com, lornsamnang.com
- [ ] Hover over phone/email/website chips — text and icon should turn red
- [ ] Confirm sketchy pill border appears on each chip
- [ ] Check on mobile (≤640px) that chips wrap correctly

https://claude.ai/code/session_01GT1wuag8znmPr2KTC6H56F

---
_Generated by [Claude Code](https://claude.ai/code/session_01GT1wuag8znmPr2KTC6H56F)_